### PR TITLE
ColorPixelGenerator bugfixes

### DIFF
--- a/sources/ppu_ColorPixelGenerator.vhd
+++ b/sources/ppu_ColorPixelGenerator.vhd
@@ -12,8 +12,8 @@ entity color_pixel_gen is
     i_enb              : in std_logic;
     i_foreground       : in std_logic_vector(4 downto 0); -- Priority, Attribute High, Attribute Low, Pattern High, Pattern Low
     i_background       : in std_logic_vector(3 downto 0); -- Attribute High, Attribute Low, Pattern High, Pattern Low
-    i_ppuctrl_bit6     : in std_logic                       := '0'; -- PPUCTRL bit 6 (PPU master/slave select)
-    io_ext             : inout std_logic_vector(3 downto 0) := (others => '0'); -- EXT input/output
+    i_ppuctrl_bit6     : in std_logic; -- PPUCTRL bit 6 (PPU master/slave select)
+    io_ext             : inout std_logic_vector(3 downto 0); -- EXT input/output
     i_palette_ram_data : in std_logic_vector(23 downto 0); -- Palette RAM data
     o_palette_ram_addr : out std_logic_vector(13 downto 0) := (others => '0'); -- Palette RAM address
     o_color_pixel      : out std_logic_vector(23 downto 0) := (others => '0')
@@ -29,33 +29,35 @@ architecture rtl of color_pixel_gen is
 begin
 
   -- Priority decision (mux_prio)
-  s_prio <= (4 => '1', 3 downto 0 => i_foreground) when (i_background(1 downto 0) = "00" and i_foreground(1 downto 0) /= "00") else -- Sprite
-    (4 => '0', 3 downto 0 => i_background) when (i_background(1 downto 0) /= "00" and i_foreground(1 downto 0) = "00") else -- Background
-    (4 => '1', 3 downto 0 => i_foreground) when (i_background(1 downto 0) /= "00" and i_foreground(1 downto 0) /= "00" and i_foreground(4) = '0') else -- Sprite priority
-    (4 => '0', 3 downto 0 => i_background); -- Background priority
+  s_prio <= (4 => '1', 3 downto 0 => i_foreground(3 downto 0)) when (i_background(1 downto 0) = "00" and i_foreground(1 downto 0) /= "00") else -- Sprite
+    (4 => '0', 3 downto 0 => i_background(3 downto 0)) when (i_background(1 downto 0) /= "00" and i_foreground(1 downto 0) = "00") else -- Background
+    (4 => '1', 3 downto 0 => i_foreground(3 downto 0)) when (i_background(1 downto 0) /= "00" and i_foreground(1 downto 0) /= "00" and i_foreground(4) = '0') else -- Sprite priority
+    (4 => '0', 3 downto 0 => i_background(3 downto 0)); -- Background priority
 
   mux_ext : process (all) is
   begin
     if i_ppuctrl_bit6 = '1' then
       io_ext <= s_prio(3 downto 0); -- Output EXT
     else
+      io_ext <= (others => 'Z'); -- Set to high-impedance for input (not driven by this module)
       if s_prio = "00000" then
         s_ext(4)          <= s_prio(4);
         s_ext(3 downto 0) <= io_ext; -- Input EXT
       else
         s_ext <= s_prio;
       end if;
+      s_addr(4 downto 0) <= s_ext; -- Address translation
     end if;
   end process;
 
-  s_addr(4 downto 0) <= s_ext; -- Address translation
-
-  palette_ram_access : process (i_clk) is
+  palette_ram_access : process (all) is
   begin
-    if rising_edge(i_clk) then
-      if i_enb = '1' then
-        o_palette_ram_addr <= s_addr;
-        o_color_pixel      <= i_palette_ram_data; -- Color value of the previous clock cycle
+    if not i_ppuctrl_bit6 then -- Only if ppu is master
+      if rising_edge(i_clk) then
+        if i_enb = '1' then
+          o_palette_ram_addr <= s_addr;
+          o_color_pixel      <= i_palette_ram_data; -- Color value of the previous clock cycle
+        end if;
       end if;
     end if;
   end process;


### PR DESCRIPTION
Fixed a bug that caused io_ext to be driven by multiple sources.
Fixed a bug that caused s_prio not to be assigned the correct signal.